### PR TITLE
Fixed issue 1: Arrow icon too far to the left.

### DIFF
--- a/blank_theme.css
+++ b/blank_theme.css
@@ -13,6 +13,7 @@
 
 /* Toggle */
 .dk_mytheme .dk_toggle {}
+	.dk_mytheme .dk_toggle:after {}
   .dk_mytheme .dk_toggle:hover {}
 
 /* Focus State */

--- a/dropkick.css
+++ b/dropkick.css
@@ -39,9 +39,6 @@
    * Help: Arrow image not appearing
    * Try updating this property to your correct dk_arrows.png path
    */
-  background-image: url('images/dk_arrows.png');
-  background-repeat: no-repeat;
-  background-position: 90% center;
   border: 1px solid #ccc;
   color: #333;
   padding: 7px 45px 7px 10px;
@@ -54,6 +51,19 @@
   -o-transition: border-color .5s;
   transition: border-color .5s;
 }
+	/* Fixed position arrows */
+	.dk_toggle:after{
+		display: block;
+		position: absolute;
+		background-image: url('images/dk_arrows.png');
+	  background-repeat: no-repeat;
+	  background-position: center center;
+		content: "";
+		height:100%;
+		width:25px;
+		right:0px;
+		top:0px;
+	}
   .dk_toggle:hover {
     border-color: #8c8c8c;
   }

--- a/examples.html
+++ b/examples.html
@@ -49,11 +49,14 @@
     }
       .dk_theme_black .dk_toggle,
       .dk_theme_black.dk_open .dk_toggle {
-        background-color: transparent;
-        background-image: url('images/dk_arrows_white.png');
         color: #fff;
         text-shadow: none;
       }
+      .dk_theme_black .dk_toggle:after,
+      .dk_theme_black.dk_open .dk_toggle:after{
+	      background-color: transparent;
+	      background-image: url('images/dk_arrows_white.png');
+	  }
       .dk_theme_black .dk_options a {
         background-color: #333;
         color: #fff;


### PR DESCRIPTION
Moved background image in pseudo-selector :after to generate a fixed size block. Block remains the same size no matter the size of the dropdown-box. Changed blank CSS-style and example.html page to match the new technique.
