### PR TITLE
Manual close method

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -182,6 +182,11 @@
       _updateFields($current, $dk, true);
     }
   };
+  
+  // Close the dropdown manually
+  methods.close = function() {
+    _closeDropdown($(this).data('dropkick').$dk);
+  }
 
   // Expose the plugin
   $.fn.dropkick = function (method) {


### PR DESCRIPTION
Added a method to close the drop down manually, useful for when you want to close the dropdown when the user clicks outside the area. For example:

$('html').click(function(e) {
  $.each($('select'), function(index, value) {
    $(value).dropkick('close');
  });
});
