### PR TITLE
Remove unnecessary e.preventDefault() statements

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -353,7 +353,6 @@
         $dk.find('.dk_options_inner').addClass('scrollable vertical');
       }
 
-      e.preventDefault();
       return false;
     });
 
@@ -369,7 +368,6 @@
       _updateFields($option, $dk);
       _setCurrent($option.parent(), $dk);
     
-      e.preventDefault();
       return false;
     });
 


### PR DESCRIPTION
"return false" is the equivalent to e.preventDefault() and e.stopPropagation(), so there isn't a need to have "return false" and e.preventDefault() in the same function. I removed 2 cases of this from the plugin.

Here is a good article talking about the differences and when to use "return false", e.preventDefault(), e.stopPropagation(), and e.stopImmediatePropagation() 

http://fuelyourcoding.com/jquery-events-stop-misusing-return-false/
