### PR TITLE
Trigger change event on original select when value changes.  Fixes gh-13

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -262,6 +262,7 @@
 
     $select = data.$select;
     $select.val(value);
+    $select.change();
 
     $dk.find('.dk_label').text(label);
 


### PR DESCRIPTION
This addresses issue #13, where `change` events on the native `select` aren't happening when the value of the dropkick element changes.  Whether the `change` event is wired up before or after dropkick is applied, this just defers to the `select` itself to trigger whatever event handlers have been wired-up.

This still calls the native `change` when the value is changed due to `reset` being called, which makes sense to me (if you want to opt out of `reset`, use the dropkick `change` option instead), but if it shouldn't be called, it can be moved into the `if (!reset)` statement, too.
