### PR TITLE
Updated the way the $id reference is selected so that ID's with brackets co...

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -121,7 +121,7 @@
       $select.before($dk);
 
       // Update the reference to $dk
-      $dk = $('#dk_container_' + id).fadeIn(settings.startSpeed);
+      $dk = $('div[id="dk_container_' + id + '"]').fadeIn(settings.startSpeed);
 
       // Save the current theme
       theme = settings.theme ? settings.theme : 'default';


### PR DESCRIPTION
...ntinue to work and display.

Quick summary:

I am building a shop and using DropKick. I have selects for the shop software that have brackets in their name, like this:

```
<select name="product_option[size]">
<option>Small</option>
<option>Medium</option>
<option>Large</option>
</select>
```

The jQuery selector you were using for fading in the newly created DropKick div was failing, so I rewrote it. This appears to be working fine though!
