### PR TITLE
thought you might want to include some of these things into master, sprites etc. are not in the commit - but easy change

### DIFF
--- a/dropkick.css
+++ b/dropkick.css
@@ -1,29 +1,29 @@
 /**
- * Default DropKick theme
- *
- * Feel free to edit the default theme
- * or even add your own.
- *
- * See the readme for themeing help
- *
- */
-
+* Default DropKick theme
+*
+* Feel free to edit the default theme
+* or even add your own.
+*
+* See the readme for themeing help
+*
+*/
+ 
 /***** Begin Theme, feel free to edit in here! ******/
-
+ 
 /* One container to bind them... */
 .dk_container {
   background: -webkit-gradient(linear, left top, left bottom, from(#fff), to(#f5f5f5));
   background: -moz-linear-gradient(top, #fff, #f5f5f5);
   background: -o-linear-gradient(top, #fff, #f5f5f5);
   background-color: #f5f5f5;
+  border-radius: 5px;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
   font-family: 'Helvetica', Arial, sans-serif;
   font-size: 12px;
   font-weight: bold;
   line-height: 14px;
   margin-bottom: 18px;
-  border-radius: 5px;
-  -moz-border-radius: 5px;
-  -webkit-border-radius: 5px;
 }
   .dk_container:focus {
     outline: 0;
@@ -32,27 +32,26 @@
     cursor: pointer;
     text-decoration: none;
   }
-
+ 
 /* Opens the dropdown and holds the menu label */
 .dk_toggle {
   /**
    * Help: Arrow image not appearing
    * Try updating this property to your correct dk_arrows.png path
    */
-  background-image: url('images/dk_arrows.png');
+  background: url("2xsprite.png") no-repeat scroll right -572px transparent;
   background-repeat: no-repeat;
-  background-position: 90% center;
   border: 1px solid #ccc;
-  color: #333;
-  padding: 7px 45px 7px 10px;
-  text-shadow: #fff 1px 1px 0;
   border-radius: 5px;
   -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
-  -webkit-transition: border-color .5s;
+  color: #333;
+  padding: 7px 45px 7px 10px;
+  text-shadow: #fff 1px 1px 0;
+  transition: border-color .5s;
   -moz-transition: border-color .5s;
   -o-transition: border-color .5s;
-  transition: border-color .5s;
+  -webkit-transition: border-color .5s;
 }
   .dk_toggle:hover {
     border-color: #8c8c8c;
@@ -66,7 +65,7 @@
     -moz-box-shadow: 0 0 5px #40b5e2;
     -webkit-box-shadow: 0 0 5px #40b5e2;
   }
-
+ 
 /* Applied whenever the dropdown is open */
 .dk_open {
   box-shadow: 0 0 5px #40b5e2;
@@ -80,22 +79,31 @@
 }
   .dk_open .dk_toggle {
     background-color: #ececec;
-    border-color: #8c8c8c;
-    color: #ccc;
-    box-shadow: inset 0 -2px 5px #ccc;
+    border-color: #6390c7;
     border-radius: 5px 5px 0 0;
     -moz-border-radius: 5px 5px 0 0;
     -webkit-border-radius: 5px 5px 0 0;
+    box-shadow: inset 0 -2px 5px #ccc;
+    color: #ccc;
   }
-
+ 
 /* The outer container of the options */
 .dk_options {
-  box-shadow: rgba(0, 0, 0, .2) 0 2px 8px;
-  -moz-box-shadow: rgba(0, 0, 0, .2) 0 2px 8px;
-  -webkit-box-shadow: rgba(0, 0, 0, .2) 0 2px 8px;
   border-radius: 0 0 5px 5px;
   -moz-border-radius: 0 0 5px 5px;
   -webkit-border-radius: 0 0 5px 5px;
+  box-shadow: rgba(0, 0, 0, .2) 0 2px 8px;
+  -moz-box-shadow: rgba(0, 0, 0, .2) 0 2px 8px;
+  -webkit-box-shadow: rgba(0, 0, 0, .2) 0 2px 8px;
+}
+ 
+.dk_flipped .dk_options  {
+  border-radius: 5px 5px 0 0;
+  -moz-border-radius: 5px 5px 0 0;
+  -webkit-border-radius: 5px 5px 0 0;
+  box-shadow: rgba(0, 0, 0, .2) 0px -4px 8px;
+  -moz-box-shadow: rgba(0, 0, 0, .2) 0px -4px 8px;
+  -webkit-box-shadow: rgba(0, 0, 0, .2) 0px -4px 8px;
 }
   .dk_options a {
     background-color: #fff;
@@ -114,39 +122,46 @@
     text-decoration: none;
     text-shadow: rgba(0, 0, 0, .5) 0 1px 0;
   }
-
+ 
 /* Inner container for options, this is what makes the scrollbar possible. */
 .dk_options_inner {
   border: 1px solid #8c8c8e;
-  border-bottom-width: 2px;
   border-bottom-color: #999;
-  color: #333;
-  max-height: 250px;
-  text-shadow: #fff 0 1px 0;
+  border-bottom-width: 2px;
+  border-color: #8C8C8E #6390C7 #6390C7;
   border-radius: 0 0 5px 5px;
   -moz-border-radius: 0 0 5px 5px;
   -webkit-border-radius: 0 0 5px 5px;
+  color: #333;
+  max-height: 250px;
+  text-shadow: #fff 0 1px 0;
 }
-
+ 
+.dk_flipped .dk_options_inner {
+  border-radius: 5px 5px 0 0;
+  -moz-border-radius: 5px 5px 0 0;
+  -webkit-border-radius: 5px 5px 0 0;
+}
+ 
 /* Set a max-height on the options inner */
 .dk_options_inner,
 .dk_touch .dk_options {
   max-height: 250px;
 }
-
+ 
 /******  End Theme ******/
-
+ 
 /***** Critical to the continued enjoyment of working dropdowns ******/
-
+ 
 .dk_container {
-  display: none;
+/* display: none;*/
   float: left;
   position: relative;
 }
   .dk_container a {
     outline: 0;
   }
-
+ 
 .dk_toggle {
   display: -moz-inline-stack;
   display: inline-block;
@@ -154,7 +169,7 @@
   position: relative;
   zoom: 1;
 }
-
+ 
 .dk_open {
   position: relative;
 }
@@ -164,7 +179,7 @@
   .dk_open .dk_label {
     color: inherit;
   }
-
+ 
 .dk_options {
   display: none;
   margin-top: -1px;
@@ -181,20 +196,31 @@
     overflow: auto;
     position: relative;
   }
-
+ 
+   .dk_option_hidden{
+    display:none;
+   }
+ 
 .dk_touch .dk_options {
   overflow: hidden;
 }
-
+ 
 .dk_touch .dk_options_inner {
   max-height: none;
   overflow: visible;
 }
-
+ 
 .dk_fouc select {
   position: relative;
-  top: -99999em;
-  visibility: hidden;
+/* top: -99999em;
+  visibility: hidden;*/
 }
-
+ 
+ 
+/*STYLES FOR MULTISELECT*/
+ 
+.dk_container .dk_options a span.checkbox {   background: url("2xsprite.png") no-repeat scroll left -609px transparent;clear: left;display: block;float: left;height: 23px;width: 30px;}
+.dk_container .dk_option_multiple.selected a span.checkbox {  background-position:0 -639px;}
+.dk_container .dk_option_multiple a {padding:8px 0px 8px 0px;}
+.dk_container .dk_option_multiple a span{margin-top:-4px;padding:0px 10px 0px 0px;}
 /***** End Critical to the continued enjoyment of working dropdowns ******/

--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -1,402 +1,634 @@
 /**
- * DropKick
- *
- * Highly customizable <select> lists
- * https://github.com/JamieLottering/DropKick
- *
- * &copy; 2011 Jamie Lottering <http://github.com/JamieLottering>
- *                        <http://twitter.com/JamieLottering>
- * 
- */
+* DropKick
+*
+* Highly customizable <select> lists
+* https://github.com/JamieLottering/DropKick
+*
+* Modified by klh to support typing in box, microtemplating and multiselect dropdowns
+*
+* &copy; 2011 Jamie Lottering <http://github.com/JamieLottering>
+*                        <http://twitter.com/JamieLottering>
+*
+*/
+ 
 (function ($, window, document) {
-
-  var ie6 = false;
-
-  // Help prevent flashes of unstyled content
-  if ($.browser.msie && $.browser.version.substr(0, 1) < 7) {
-    ie6 = true;
-  } else {
-    document.documentElement.className = document.documentElement.className + ' dk_fouc';
-  }
-  
-  var
+ 
+    var ie6 = false;
+ 
+    // Help prevent flashes of unstyled content
+    if ($.browser.msie && $.browser.version.substr(0, 1) < 7) {
+        ie6 = true;
+    } else {
+        document.documentElement.className = document.documentElement.className + ' dk_fouc';
+    }
+ 
+    var
     // Public methods exposed to $.fn.dropkick()
     methods = {},
-
+ 
     // Cache every <select> element that gets dropkicked
-    lists   = [],
-
+    lists = [],
+ 
+    // Cache rendering of dropdowns for resig microtemplating
+    renderCache = [],
+ 
     // Convenience keys for keyboard navigation
     keyMap = {
-      'left'  : 37,
-      'up'    : 38,
-      'right' : 39,
-      'down'  : 40,
-      'enter' : 13
+        'esc': 27,
+        'space': 32,
+        'left': 37,
+        'up': 38,
+       'right': 39,
+        'down': 40,
+        'enter': 13,
+        'zero': 48,
+        'last': 221  //support extend charsets such as Danish, Ukrainian etc.
     },
-
-    // HTML template for the dropdowns
-    dropdownTemplate = [
-      '<div class="dk_container" id="dk_container_{{ id }}" tabindex="{{ tabindex }}">',
+ 
+    // HTML template for the dropdowns (using resig microtemplating)
+    microDropdownTemplate = [
+      '<div class="dk_container" id="dk_container_<%=id%>" tabindex="<%=tabindex%>">',
         '<a class="dk_toggle">',
-          '<span class="dk_label">{{ label }}</span>',
+          '<span class="dk_label"><%=label%></span>',
         '</a>',
         '<div class="dk_options">',
           '<ul class="dk_options_inner">',
+          '<%  for(var key=0, len=options.length; key < len; key++){%>',
+          '<li class="<%if(!options[key].display){%>dk_option_hidden <%}%><%if(options[key].current){%>dk_option_current <%}%><%if(options[key].selected){%>selected <%}%><%if(multiple){%>dk_option_multiple<%}%>" >',
+              '<a data-dk-dropdown-value="<%=options[key].value%>">',
+               '<%if(multiple){%><span class="checkbox"></span><%}%>',
+              '<%=options[key].text%></a>',
+          '</li>',
+          '<% } %>',
           '</ul>',
         '</div>',
       '</div>'
     ].join(''),
-
-    // HTML template for dropdown options
-    optionTemplate = '<li class="{{ current }}"><a data-dk-dropdown-value="{{ value }}">{{ text }}</a></li>',
-
+ 
+ 
     // Some nice default values
     defaults = {
-      startSpeed : 1000,  // I recommend a high value here, I feel it makes the changes less noticeable to the user
-      theme  : false,
-      change : false
+        startSpeed: 10,
+        theme: false,
+        change: false,
+        fixed: true
     },
-
+ 
     // Make sure we only bind keydown on the document once
     keysBound = false
   ;
-
-  // Called by using $('foo').dropkick();
-  methods.init = function (settings) {
-    settings = $.extend({}, defaults, settings);
-
-    return this.each(function () {
-      var
-        // The current <select> element
+ 
+    // Called by using $('foo').dropkick();
+    methods.init = function (settings) {
+ 
+        settings = $.extend({}, defaults, settings);
+ 
+        return this.each(function () {
+            var
+            // The current <select> element
         $select = $(this),
-
-        // Store a reference to the originally selected <option> element
+ 
+            // Store a reference to the originally selected <option> element
         $original = $select.find(':selected').first(),
-
-        // Save all of the <option> elements
+ 
+            // Save all of the <option> elements
         $options = $select.find('option'),
-
-        // We store lots of great stuff using jQuery data
+ 
+            // We store lots of great stuff using jQuery data
         data = $select.data('dropkick') || {},
-
-        // This gets applied to the 'dk_container' element
+ 
+            // This gets applied to the 'dk_container' element
         id = $select.attr('id') || $select.attr('name'),
-
-        // This gets updated to be equal to the longest <option> element
-        width  = settings.width || $select.outerWidth(),
-
-        // Check if we have a tabindex set or not
-        tabindex  = $select.attr('tabindex') ? $select.attr('tabindex') : '',
-
-        // The completed dk_container element
+ 
+            // This gets updated to be equal to the longest <option> element
+        width = settings.width || $select.outerWidth(),
+ 
+            // Check if we have a tabindex set or not
+        tabindex = $select.attr('tabindex') ? $select.attr('tabindex') : '',
+ 
+            // The completed dk_container element
         $dk = false,
-
+ 
         theme
       ;
-
-      // Dont do anything if we've already setup dropkick on this element
-      if (data.id) {
-        return $select;
-      } else {
-        data.settings  = settings;
-        data.tabindex  = tabindex;
-        data.id        = id;
-        data.$original = $original;
-        data.$select   = $select;
-        data.value     = _notBlank($select.val()) || _notBlank($original.attr('value'));
-        data.label     = $original.text();
-        data.options   = $options;
-      }
-
-      // Build the dropdown HTML
-      $dk = _build(dropdownTemplate, data);
-
-      // Make the dropdown fixed width if desired
-      $dk.find('.dk_toggle').css({
-        'width' : width + 'px'
-      });
-
-      // Hide the <select> list and place our new one in front of it
-      $select.before($dk);
-
-      // Update the reference to $dk
-      $dk = $('#dk_container_' + id).fadeIn(settings.startSpeed);
-
-      // Save the current theme
-      theme = settings.theme ? settings.theme : 'default';
-      $dk.addClass('dk_theme_' + theme);
-      data.theme = theme;
-
-      // Save the updated $dk reference into our data object
-      data.$dk = $dk;
-
-      // Save the dropkick data onto the <select> element
-      $select.data('dropkick', data);
-
-      // Do the same for the dropdown, but add a few helpers
-      $dk.data('dropkick', data);
-
-      lists[lists.length] = $select;
-
-      // Focus events
-      $dk.bind('focus.dropkick', function (e) {
-        $dk.addClass('dk_focus');
-      }).bind('blur.dropkick', function (e) {
-        $dk.removeClass('dk_open dk_focus');
-      });
-
-      setTimeout(function () {
-        $select.hide();
-      }, 0);
-    });
-  };
-
-  // Allows dynamic theme changes
-  methods.theme = function (newTheme) {
-    var
-      $select   = $(this),
-      list      = $select.data('dropkick'),
-      $dk       = list.$dk,
-      oldtheme  = 'dk_theme_' + list.theme
+            // Bind to original selector - so that changes propagate up to
+            // Custom dropdown
+ 
+            $select.live("change.saxo", function (e) {
+                _doUpdateFromFormSelect(e)
+            });
+ 
+            // Dont do anything if we've already setup dropkick on this element
+            if (data.id) {
+                return $select;
+            } else {
+                data.settings = settings;
+                data.tabindex = tabindex;
+                data.id = id;
+                data.$original = $original;
+                data.$select = $select;
+                data.value = _notBlank($select.val()) || _notBlank($original.attr('value'));
+                data.label = $original.text();
+                data.defaultLabel = $select.attr('data-label');
+                data.options = $options;
+                data.multiple = ($select.attr("multiple") == "multiple") ? true : false;
+ 
+            }
+ 
+            // Build the dropdown HTML   
+ 
+            $dk = _builds(microDropdownTemplate, data);
+ 
+ 
+            // Make the dropdown fixed width if desired
+            if (settings.fixed) {
+                $dk.find('.dk_toggle').css({
+                    'width': width + 'px'
+                });
+            }
+ 
+            // Hide the <select> list and place our new one in front of it
+            $select.before($dk);
+ 
+            // Update the reference to $dk
+            $dk = $('#dk_container_' + id).fadeIn(settings.startSpeed);
+ 
+            // Save the current theme
+            theme = settings.theme ? settings.theme : 'default';
+            $dk.addClass('dk_theme_' + theme);
+            data.theme = theme;
+ 
+            // Save the updated $dk reference into our data object
+            data.$dk = $dk;
+ 
+            // Save the dropkick data onto the <select> element
+            $select.data('dropkick', data);
+ 
+            // Do the same for the dropdown, but add a few helpers
+            $dk.data('dropkick', data);
+ 
+            lists[lists.length] = $select;
+ 
+            // Changed from blur and focus to focus in/out
+            // Focus events
+            $dk.bind('focusIn.dropkick', function (e) {
+                $dk.addClass('dk_focus');
+            }).bind('focusOut.dropkick', function (e) {
+                $dk.removeClass('dk_open dk_focus');
+            });
+ 
+            $select.bind('focusIn.dropkick', function (e) {
+                $dk.focus();
+                e.preventDefault();
+            });
+ 
+            $('body').on("click", function (event) {
+                if (!$(event.target).parents('.dk_container').length) {
+                    _closeDropdown($dk);
+                }
+            });
+            setTimeout(function () {
+                //$select.hide();
+            }, 0);
+        });
+ 
+ 
+ 
+    };
+ 
+    // Allows dynamic theme changes
+    methods.theme = function (newTheme) {
+        var
+      $select = $(this),
+      list = $select.data('dropkick'),
+      $dk = list.$dk,
+      oldtheme = 'dk_theme_' + list.theme
     ;
-
-    $dk.removeClass(oldtheme).addClass('dk_theme_' + newTheme);
-
-    list.theme = newTheme;
-  };
-
-  // Reset all <selects and dropdowns in our lists array
-  methods.reset = function () {
-    for (var i = 0, l = lists.length; i < l; i++) {
-      var
-        listData  = lists[i].data('dropkick'),
-        $dk       = listData.$dk,
-        $current  = $dk.find('li').first()
+ 
+        $dk.removeClass(oldtheme).addClass('dk_theme_' + newTheme);
+ 
+        list.theme = newTheme;
+    };
+ 
+    // Reset all <selects and dropdowns in our lists array
+    methods.reset = function () {
+        for (var i = 0, l = lists.length; i < l; i++) {
+            var
+        listData = lists[i].data('dropkick'),
+        $dk = listData.$dk,
+        $current = $dk.find('li').first()
       ;
-
-      $dk.find('.dk_label').text(listData.label);
-      $dk.find('.dk_options_inner').animate({ scrollTop: 0 }, 0);
-
-      _setCurrent($current, $dk);
-      _updateFields($current, $dk, true);
-    }
-  };
-
-  // Expose the plugin
-  $.fn.dropkick = function (method) {
-    if (!ie6) {
-      if (methods[method]) {
-        return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
-      } else if (typeof method === 'object' || ! method) {
-        return methods.init.apply(this, arguments);
-      }
-    }
-  };
-
-  // private
-  function _handleKeyBoardNav(e, $dk) {
-    var
-      code     = e.keyCode,
-      data     = $dk.data('dropkick'),
-      options  = $dk.find('.dk_options'),
-      open     = $dk.hasClass('dk_open'),
-      current  = $dk.find('.dk_option_current'),
-      first    = options.find('li').first(),
-      last     = options.find('li').last(),
+ 
+            _updateLabelText($dk.find('.dk_label'), $dk, listData.label, data)
+            $dk.find('.dk_options_inner').animate({ scrollTop: 0 }, 0);
+ 
+            _setCurrent($current, $dk);
+            _updateFields($current, $dk, true);
+        }
+    };
+ 
+    // Expose the plugin
+    $.fn.dropkick = function (method) {
+        if (!ie6) {
+            if (methods[method]) {
+                return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
+            } else if (typeof method === 'object' || !method) {
+                return methods.init.apply(this, arguments);
+            }
+        }
+    };
+ 
+    // private
+ 
+    function _renderTemplate(str, data) {
+        // Simple JavaScript Templating
+        // John Resig - http://ejohn.org/ - MIT Licensed
+        // modified!!!!
+        // Figure out if we're getting a template, or if we need to
+        // load the template - and be sure to cache the result.
+        var fn = !/\W/.test(str) ?
+       renderCache[str] = renderCache[str] ||
+        renderTemplate(document.getElementById(str).innerHTML) :
+ 
+        // Generate a reusable function that will serve as a template
+        // generator (and which will be cached).
+      new Function("obj",
+        "var p=[],print=function(){p.push.apply(p,arguments);};" +
+ 
+        // Introduce the data as local variables using with(){}
+        "with(obj){p.push('" +
+ 
+        // Convert the template into pure JavaScript
+        str
+          .replace(/[\r\t\n]/g, " ")
+          .split("<%").join("\t")
+          .replace(/((^|%>)[^\t]*)'/g, "$1\r")
+          .replace(/\t=(.*?)%>/g, "',$1,'")
+          .split("\t").join("');")
+          .split("%>").join("p.push('")
+          .split("\r").join("\\'")
+      + "');}return p.join('');");
+ 
+        // Provide some basic currying to the user
+        return data ? fn(data) : fn;
+    };
+ 
+    function _handleKeyBoardNav(e, $dk) {
+        var
+      code = e.keyCode,
+      data = $dk.data('dropkick'),
+      options = $dk.find('.dk_options'),
+      letter = String.fromCharCode(code),
+      open = $dk.hasClass('dk_open'),
+      lis = options.find('li'),
+      current = $dk.find('.dk_option_current'),
+      first = lis.first(),
+      last = lis.last(),
       next,
       prev
     ;
-
-    switch (code) {
-      case keyMap.enter:
-        if (open) {
-          _updateFields(current.find('a'), $dk);
-          _closeDropdown($dk);
-        } else {
-          _openDropdown($dk);
+ 
+        var multiple = data.multiple;
+        switch (code) {
+ 
+            case keyMap.enter:
+                if (open) {
+                    if (!multiple) {
+                        _updateFields(current.find("a"), $dk, false, false);
+                        _closeDropdown($dk)
+                    } else {
+                        _updateFields(current.find("a"), $dk, true, false);
+                    }
+                } else {
+                    _openDropdown($dk);
+                }
+                e.preventDefault();
+                break;
+            case keyMap.space:
+                if (open) {
+                    if (!multiple) {
+                        _updateFields(current.find("a"), $dk, false, false);
+                        _closeDropdown($dk)
+                    } else {
+                        _updateFields(current.find("a"), $dk, true, false);
+                    }
+                } else {
+                    _openDropdown($dk);
+                }
+                e.preventDefault();
+                break;
+ 
+            case keyMap.up:
+                prev = current.prev('li');
+                if (open) {
+                    if (prev.length) {
+                        _setCurrent(prev, $dk);
+                    } else {
+                        _setCurrent(last, $dk);
+                    }
+                } else {
+                    _openDropdown($dk);
+                }
+                e.preventDefault();
+                break;
+ 
+            case keyMap.down:
+                if (open) {
+                    next = current.next('li').first();
+                    if (next.length) {
+                        _setCurrent(next, $dk);
+                    } else {
+                        _setCurrent(first, $dk);
+                    }
+                } else {
+                    _openDropdown($dk);
+                }
+                e.preventDefault();
+                break;
+            case keyMap.esc:
+                if (open) {
+                    _closeDropdown($dk);
+                }
+                e.preventDefault();
+                break;
+ 
+            default:
+                break;
         }
-        e.preventDefault();
-      break;
-
-      case keyMap.up:
-        prev = current.prev('li');
-        if (open) {
-          if (prev.length) {
-            _setCurrent(prev, $dk);
-          } else {
-            _setCurrent(last, $dk);
-          }
-        } else {
-          _openDropdown($dk);
+ 
+        //if typing a letter
+        if (code >= keyMap.zero && code <= keyMap.last) {
+            //update data
+            var now = new Date().getTime();
+            if (data.finder == null) {
+                data.finder = letter.toUpperCase();
+                data.timer = now;
+ 
+            } else {
+                if (now > parseInt(data.timer) + 500) {
+                    data.finder = letter.toUpperCase();
+                    data.timer = now;
+                } else {
+                    data.finder = data.finder + letter.toUpperCase();
+                    data.timer = now;
+                }
+ 
+            }
+            //find and switch to the appropriate option
+            var list = lis.find('a');
+ 
+            for (var i = 0, len = list.length; i < len; i++) {
+                var $a = $(list[i]);
+                if ($a.text().toUpperCase().indexOf(data.finder) === 0) {
+                    if (!multiple) { _updateFields($a, $dk, false, true); }
+                    _setCurrent($a.parent(), $dk);
+                    break;
+                }
+            }
+            $dk.data('dropkick', data);
         }
-        e.preventDefault();
-      break;
-
-      case keyMap.down:
-        if (open) {
-          next = current.next('li').first();
-          if (next.length) {
-            _setCurrent(next, $dk);
-          } else {
-            _setCurrent(first, $dk);
-          }
-        } else {
-          _openDropdown($dk);
-        }
-        e.preventDefault();
-      break;
-
-      default:
-      break;
     }
-  }
-
-  // Update the <select> value, and the dropdown label
-  function _updateFields(option, $dk, reset) {
-    var value, label, data;
-
-    value = option.attr('data-dk-dropdown-value');
-    label = option.text();
-    data  = $dk.data('dropkick');
-
-    $select = data.$select;
-    $select.val(value);
-
-    $dk.find('.dk_label').text(label);
-
-    reset = reset || false;
-
-    if (data.settings.change && !reset) {
-      data.settings.change.call($select, value, label);
-    }
-  }
-
-  // Set the currently selected option
-  function _setCurrent($current, $dk) {
-    $dk.find('.dk_option_current').removeClass('dk_option_current');
-    $current.addClass('dk_option_current');
-
-    _setScrollPos($dk, $current);
-  }
-
-  function _setScrollPos($dk, anchor) {
-    var height = anchor.prevAll('li').outerHeight() * anchor.prevAll('li').length;
-    $dk.find('.dk_options_inner').animate({ scrollTop: height + 'px' }, 0);
-  }
-
-  // Close a dropdown
-  function _closeDropdown($dk) {
-    $dk.removeClass('dk_open');
-  }
-
-  // Open a dropdown
-  function _openDropdown($dk) {
-    var data = $dk.data('dropkick');
-    $dk.find('.dk_options').css({ top : $dk.find('.dk_toggle').outerHeight() - 1 });
-    $dk.toggleClass('dk_open');
-
-  }
-
-  /**
-   * Turn the dropdownTemplate into a jQuery object and fill in the variables.
-   */
-  function _build (tpl, view) {
-    var
-      // Template for the dropdown
-      template  = tpl,
-      // Holder of the dropdowns options
-      options   = [],
-      $dk
-    ;
-
-    template = template.replace('{{ id }}', view.id);
-    template = template.replace('{{ label }}', view.label);
-    template = template.replace('{{ tabindex }}', view.tabindex);
-
-    if (view.options && view.options.length) {
-      for (var i = 0, l = view.options.length; i < l; i++) {
+ 
+    // Update the <select> value, and the dropdown label
+    function _updateFields(option, $dk, reset, dontclose) {
+ 
         var
-          $option   = $(view.options[i]),
-          current   = 'dk_option_current',
-          oTemplate = optionTemplate
-        ;
-
-        oTemplate = oTemplate.replace('{{ value }}', $option.val());
-        oTemplate = oTemplate.replace('{{ current }}', (_notBlank($option.val()) === view.value) ? current : '');
-        oTemplate = oTemplate.replace('{{ text }}', $option.text());
-
-        options[options.length] = oTemplate;
-      }
+    value = option.attr('data-dk-dropdown-value'),
+    label = option.text(),
+    listItem = option.parent(),
+    data = $dk.data('dropkick'),
+    options = $dk.find('.dk_options'),
+    selectedIndicator,
+    currentOption;
+ 
+        $select = data.$select;
+ 
+        if (data.multiple) {
+            listItem.toggleClass("selected")
+        } else {
+            listItem.siblings("li.selected").removeClass("selected");
+            listItem.addClass("selected");
+        }
+        selectedIndicator = option.parent().is(".selected");
+        currentOption = $select.find("option").eq(listItem.index());
+ 
+        _setSelectedFormItems(currentOption, selectedIndicator)
+ 
+ 
+        reset = reset || false;
+ 
+        if (data.settings.change && !reset) {
+            data.settings.change.call($select, value, label);
+        }
+ 
+ 
+ 
+        if (!data.multiple && !dontclose) {
+            _closeDropdown($dk);
+            _setCurrent(option, $dk, true);
+        } else {
+            _setCurrent(option, $dk, true);
+        }
+        _updateLabelText($dk.find('.dk_label'), $dk, label, data)
+        $select.change();
     }
-
-    $dk = $(template);
-    $dk.find('.dk_options_inner').html(options.join(''));
-
-    return $dk;
-  }
-
-  function _notBlank(text) {
-    return ($.trim(text).length > 0) ? text : false;
-  }
-
-  $(function () {
-
-    // Handle click events on the dropdown toggler
-    $('.dk_toggle').live('click', function (e) {
-      var $dk  = $(this).parents('.dk_container').first();
-
-      _openDropdown($dk);
-
-      if ("ontouchstart" in window) {
-        $dk.addClass('dk_touch');
-        $dk.find('.dk_options_inner').addClass('scrollable vertical');
+ 
+ 
+    // update selection index on form select element
+    function _setSelectedFormItems(listItem, selected) {
+        listItem.attr("selected", selected);
+    }
+ 
+    function _doUpdateFromFormSelect(e) {
+      if(e.originalEvent){
+        var $select = $(e.target),
+          data = $select.data('dropkick'),
+          $dk = data.$dk,
+          $listItems = $dk.find(".dk_options_inner li"),
+          dataValue = $select.val();
+        if (dataValue)
+ 
+            realindex = $listItems.filter(function () {
+                var d = $(this).find("a").attr('data-dk-dropdown-value');
+                if ($.trim(d).length === 0) { return false; }
+                return dataValue.toString().indexOf(d) !== -1;
+            });
+ 
+        $listItems.removeClass("selected dk_option_current");
+        realindex.addClass("selected");
+        if (realindex.length == 1) {
+            realindex.addClass("dk_option_current")
+        }
+        _updateLabelText($dk.find("span.dk_label"), $dk, realindex.first().find("a").text(), data);
+      }else{
+        return false;
       }
-
-      e.preventDefault();
-      return false;
-    });
-
-    // Handle click events on individual dropdown options
-    $('.dk_options a').live(($.browser.msie ? 'mousedown' : 'click'), function (e) {
-      var
+    };
+ 
+ 
+ 
+    // update label on dropdown
+    function _updateLabelText($current, $dk, label, data) {
+        var selectedNum = $dk.find("li.selected").length;
+        if (data.multiple) {
+            label = (selectedNum > 1) ? selectedNum + " selected" : label;
+        }
+        if (!selectedNum) {
+            label = data.defaultLabel;
+        }
+ 
+        $current.text(label)
+    }
+ 
+    // Set the currently selected option
+    function _setCurrent($current, $dk) {
+        data = $dk.data('dropkick');
+        $dk.find('.dk_option_current').removeClass('dk_option_current');
+ 
+        if (!data.multiple) {
+ 
+            _setScrollPos($dk, $current);
+        }
+            $current.addClass('dk_option_current');
+    
+ 
+    }
+ 
+    function _setScrollPos($dk, anchor) {
+        var height = anchor.prevAll('li').outerHeight() * anchor.prevAll('li').length;
+        $dk.find('.dk_options_inner').animate({ scrollTop: height + 'px' }, 0);
+    }
+ 
+    // Close a dropdown
+    function _closeDropdown($dk) {
+        $dk.removeClass('dk_open');
+    }
+ 
+    // Open a dropdown
+    function _openDropdown($dk) {
+        var data = $dk.data('dropkick');
+        if (_isThereSpace($dk, 250)) {
+            $dk.find('.dk_options').css({ top: $dk.find('.dk_toggle').outerHeight() - 1 });
+            $dk.removeClass('dk_flipped');
+        } else {
+            $dk.find('.dk_options').css({ top: ($dk.find('.dk_options').outerHeight() - 4) * -1 });
+            $dk.addClass('dk_flipped');
+        }
+ 
+        $dk.toggleClass('dk_open');
+    }
+ 
+ 
+    /**
+    * Turn the dropdownTemplate into a jQuery object and fill in the variables.
+    * refactored to use microtemplating
+    */
+    function _builds(tpl, view) {
+ 
+        var
+        // Template for the dropdown
+      template = tpl,
+        // Holder of the dropdowns options
+      data = {
+          id: view.id,
+          label: view.label,
+          tabindex: view.tabindex,
+          multiple: view.multiple,
+          options: []
+      },
+      $dk;
+ 
+        if (view.options && view.options.length) {
+            $.map(view.options, function (val, i) {
+                data.options[i] = {};
+                data.options[i].value = $(val).val();
+                data.options[i].text = $(val).text();
+                data.options[i].selected = ($(val).attr("selected") == "selected") ? true : false;
+                data.options[i].current = (_notBlank(data.options[i].value) === view.value) ? true : false;
+                data.options[i].display = ($.trim(data.options[i].value).length > 0) ? true : false;
+            });
+        }
+ 
+        $dk = $(_renderTemplate(microDropdownTemplate, data));
+        _updateLabelText($dk.find('.dk_label'), $dk, data.label, view)
+        return $dk;
+ 
+    }
+ 
+    function _notBlank(text) {
+        return ($.trim(text).length > 0) ? text : false;
+    }
+ 
+    function _isThereSpace(elem, spaceNeded) {
+        var docViewTop = jQuery(window).scrollTop()
+      , docViewBottom = Math.ceil(docViewTop + jQuery(window).height())
+      , elemTop = jQuery(elem).offset().top
+      , elemBottom = Math.ceil(elemTop + jQuery(elem).height())
+      , checkValue = elemBottom + spaceNeded;
+ 
+        if (checkValue >= docViewBottom) {
+            return false
+        } else {
+            return true
+        }
+ 
+    }
+ 
+    $(function () {
+ 
+        // Handle click events on the dropdown toggler
+        $('.dk_toggle').live('click', function (e) {
+            var $dk = $(this).parents('.dk_container').first();
+ 
+            _openDropdown($dk);
+ 
+            if ("ontouchstart" in window) {
+                $dk.addClass('dk_touch');
+                $dk.find('.dk_options_inner').addClass('scrollable vertical');
+            }
+ 
+            e.preventDefault();
+            return false;
+        });
+ 
+        // Handle click events on individual dropdown options
+        $('.dk_options a').live(($.browser.msie ? 'mousedown' : 'click'), function (e) {
+            var
         $option = $(this),
-        $dk     = $option.parents('.dk_container').first(),
-        data    = $dk.data('dropkick')
+        $dk = $option.parents('.dk_container').first(),
+        data = $dk.data('dropkick')
       ;
-    
-      _closeDropdown($dk);
-      _updateFields($option, $dk);
-      _setCurrent($option.parent(), $dk);
-    
-      e.preventDefault();
-      return false;
-    });
-
-    // Setup keyboard nav
-    $(document).bind('keydown.dk_nav', function (e) {
-      var
-        // Look for an open dropdown...
-        $open    = $('.dk_container.dk_open'),
-
-        // Look for a focused dropdown
+            _updateFields($option, $dk, true);
+            e.preventDefault();
+            return false;
+        });
+       
+ 
+        // Setup keyboard nav
+        $(document).bind('keydown.dk_nav', function (e) {
+            var
+            // Look for an open dropdown...
+        $open = $('.dk_container.dk_open'),
+ 
+            // Look for a focused dropdown
         $focused = $('.dk_container.dk_focus'),
-
-        // Will be either $open, $focused, or null
+ 
+            // Will be either $open, $focused, or null
         $dk = null
       ;
-
-      // If we have an open dropdown, key events should get sent to that one
-      if ($open.length) {
-        $dk = $open;
-      } else if ($focused.length && !$open.length) {
-        // But if we have no open dropdowns, use the focused dropdown instead
-        $dk = $focused;
-      }
-
-      if ($dk) {
-        _handleKeyBoardNav(e, $dk);
-      }
+ 
+            // If we have an open dropdown, key events should get sent to that one
+            if ($open.length) {
+                $dk = $open;
+            } else if ($focused.length && !$open.length) {
+                // But if we have no open dropdowns, use the focused dropdown instead
+                $dk = $focused;
+            }
+ 
+            if ($dk) {
+                _handleKeyBoardNav(e, $dk);
+ 
+            }
+        });
     });
-  });
 })(jQuery, window, document);


### PR DESCRIPTION
Added ability to render MultiSelect dropdowns
Removed string replacement template and implemented a John Resig
microtemplating system
Added binding to listen for original select element changes
Added trigger to fire select element change() on change
Expanded "last" valid letter keymap space to include NON-US languages
Added possibility to define in settings if fixed width should be
enabled or not (possible to set on init instead of meesing with code)
Added possibility to define a default-label via data-label on select
element
Added template for use in templating engine
Typing now jumps to typed name and waits for longer to capture several
letters instead of just the first
Added new styles to support a FLIPPED display if the dropdown when
expanded overflows current pageview
added _isThereSpace function to check if there is space enough to
display the dropdown on the page - if not apply the flipped style
