### PR TITLE
Dropkick keypress select made worked

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -209,6 +209,30 @@
         </fieldset>
       </div>
 
+        <div class="example">
+          <h2>Select boxes with numbers</h2>
+          <fieldset>
+            <form action="#" method="post" accept-charset="utf-8" class="example_form">
+              <select name="number" class="change" tabindex="4">
+                <option value="">Please select a number</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+                <option value="7">7</option>
+                <option value="8">8</option>
+                <option value="9">9</option>
+                <option value="0">0</option>
+              </select>
+              <div style="clear: both;"></div>
+              <script src="https://gist.github.com/1062688.js?file=dropkick_example_callback.js"></script>
+            </form>
+          </fieldset>
+        </div>
+
+
       <div class="example">
         <h2>Creating custom themes</h2>
         <fieldset>

--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -264,6 +264,10 @@
 
       default:
           /////////////////////////////Changed by Paritosh for keys to work //////////////////////////////////
+
+          // added to recognize num key pad  (Thanks to David Cumps)
+          code = (code >= 96 && code <=105)? code-48: code;
+
           if ((code>=48 && code<=57) || (code>=65 && code<=90)){
               var dk_parent = $(current).parent();
               var dk_find = 'a[data-dk-dropdown-text^=\"'+String.fromCharCode(code)+'\"]';


### PR DESCRIPTION
A key like 'k' when pressed, it will select the option starting with 'k'. It is case insensitive operation.
It works for one letter only. For example if you press 'm' it will select option starting with 'm'.
If there is no option with 'm', nothing happens.
