### PR TITLE
Fixed issue #58

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -105,7 +105,7 @@
         data.$original = $original;
         data.$select   = $select;
         data.value     = _notBlank($select.val()) || _notBlank($original.attr('value'));
-        data.label     = $original.text();
+        data.label     = $original.html();
         data.options   = $options;
       }
 
@@ -324,7 +324,7 @@
 
         oTemplate = oTemplate.replace('{{ value }}', $option.val());
         oTemplate = oTemplate.replace('{{ current }}', (_notBlank($option.val()) === view.value) ? current : '');
-        oTemplate = oTemplate.replace('{{ text }}', $option.text());
+        oTemplate = oTemplate.replace('{{ text }}', $option.html());
 
         options[options.length] = oTemplate;
       }


### PR DESCRIPTION
Hi,

I've been using Dropkick for a while and ran into a problem described in issue #58 (https://github.com/JamieLottering/DropKick/issues/58)

The problem is that if one of the labels contains '<' and '>', it is displayed as an html element instead of just simple text.

This is an example that reproduces the error: http://jsfiddle.net/FRSMM/ (both dropdowns work OK without dropkick: http://jsfiddle.net/FRSMM/1/)

The solution I found was to use `.html()` to get the label text instead of `.text()`, because the former returns the html encoded version, which is what we need.

This is how it works after the fix: http://jsfiddle.net/FRSMM/2/

Thanks for this great library!
