### PR TITLE
Triggers "change" event on select on _updateFields()

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -183,6 +183,12 @@
     }
   };
 
+  methods.setValue = function (value) {
+    var $dk = $(this).data('dropkick').$dk;
+    var $option = $dk.find('.dk_options a[data-dk-dropdown-value="' + value + '"]');
+    _updateFields($option, $dk);
+  };
+
   // Expose the plugin
   $.fn.dropkick = function (method) {
     if (!ie6) {


### PR DESCRIPTION
There's a option "change" to pass a callback for when you select another option, but this way now you can listen to the select's "change" event after the plugin is already initialized.
This also allows for more code modularity because now you can initialize the plugin in one place and listen for that select's "change" event in another plugin.
