### PR TITLE
Fire change event on original element when selecting a new value

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -262,6 +262,7 @@
 
     $select = data.$select;
     $select.val(value);
+    $select.trigger('change');
 
     $dk.find('.dk_label').text(label);
 


### PR DESCRIPTION
Resolved an issue with Knockout JavaScript library where the model would not update when changing the value of a DropKick'd select element.
