### PR TITLE
Fix browser detection to make dropkick work in IE 10

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -13,7 +13,7 @@
   var ie6 = false;
 
   // Help prevent flashes of unstyled content
-  if ($.browser.msie && $.browser.version.substr(0, 1) < 7) {
+  if ($.browser.msie && $.browser.version.match(/^(\d+)\./)[1] < 7) {
     ie6 = true;
   } else {
     document.documentElement.className = document.documentElement.className + ' dk_fouc';


### PR DESCRIPTION
The code as it stands reject IE10 as it thinks that it is a version  < 7.

There seems to be an issue with rounded corners not working in IE10, but I couldn't see anywhere where border-radius was being set on a browser by browser basis. Perhaps an IE10 bug?
