### PR TITLE
fix: if two selects have one same name in a page

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -121,7 +121,7 @@
       $select.before($dk);
 
       // Update the reference to $dk
-      $dk = $('#dk_container_' + id).fadeIn(settings.startSpeed);
+      $dk = $select.prev('#dk_container_' + id).fadeIn(settings.startSpeed);
 
       // Save the current theme
       theme = settings.theme ? settings.theme : 'default';


### PR DESCRIPTION
Currently, if I have two forms in a page, 
and both of them have a select field named "favorite",
then the later one will be messed up,
because both of them will have the same id.
