### PR TITLE
Fix natural tab order using tabindex="0"

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -87,7 +87,8 @@
         width  = settings.width || $select.outerWidth(),
 
         // Check if we have a tabindex set or not
-        tabindex  = $select.attr('tabindex') ? $select.attr('tabindex') : '',
+        tabindex  = $select.attr('tabindex').toString(),
+        tabindex  = (typeof tabindex !== 'undefined' || tabindex !== '-1') ? tabindex : '',
 
         // The completed dk_container element
         $dk = false,


### PR DESCRIPTION
Tabindex attribute was required to be non-zero which was disrupting the
natural tab order of elements as they are rendered. Cast tabindex to
string and modified condition for fix.
