### PR TITLE
Fix tabindex natural tab order for rendered elements. 

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -87,8 +87,8 @@
         width  = settings.width || $select.outerWidth(),
 
         // Check if we have a tabindex set or not
-        tabindex  = $select.attr('tabindex').toString(),
-        tabindex  = (typeof tabindex !== 'undefined' || tabindex !== '-1') ? tabindex : '',
+        tabindex  = $select.attr('tabindex').toString(), // undefined/null will be parsed as zero by jQuery.
+        tabindex  = (tabindex !== '-1') ? tabindex : '',
 
         // The completed dk_container element
         $dk = false,


### PR DESCRIPTION
jQuery will return zero for attr('tabindex'), resulting in empty string. Cast tabindex as string to accomodate natural tab order for elements rendered.
