### PR TITLE
Added "refresh" method to update content changed dinamically

### DIFF
--- a/jquery.dropkick-1.0.0.js
+++ b/jquery.dropkick-1.0.0.js
@@ -6,7 +6,7 @@
  *
  * &copy; 2011 Jamie Lottering <http://github.com/JamieLottering>
  *                        <http://twitter.com/JamieLottering>
- * 
+ *
  */
 (function ($, window, document) {
 
@@ -18,7 +18,7 @@
   if (!ie6) {
     document.documentElement.className = document.documentElement.className + ' dk_fouc';
   }
-  
+
   var
     // Public methods exposed to $.fn.dropkick()
     methods = {},
@@ -183,6 +183,19 @@
     }
   };
 
+  // Regenerating dk wrapper to update it's content
+  // http://stackoverflow.com/a/13280151
+  methods.refresh = function(){
+    return this.each(function () {
+      var
+        $select   = $(this),
+        data      = $select.data('dropkick');
+
+      $select.removeData("dropkick");
+      $("#dk_container_"+ data.id).remove();
+      $select.dropkick(data.settings);
+    });
+  };
   // Expose the plugin
   $.fn.dropkick = function (method) {
     if (!ie6) {

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,8 @@ DropKick works by transforming your existing, boring `<select>` lists into beaut
 When an option is selected in a DropKick menu, the corresponding `<select>` value is updated. This means that your forms and AJAX requests should work the same without having to make any changes. However, if you previously had
 an `onchange` event bound to your `<select>` list, you will have to instead use a DropKick change event. Please see examples.html for usage
 
+Use `$(object).dropkick('refresh')` method to update dropkick if the `<select>` content has changed dinamically
+
 Features:
 -
 * *Keyboard Navigation:*


### PR DESCRIPTION
Added a new method to refresh the drop down wrapper if the select content changes dynamically.
## How it works:

Use `$(object).dropkick('refresh')` method to update dropkick if the `<select>` content has changed dynamically

Used this Stack Overflow solution as a base
http://stackoverflow.com/a/13280151
