### PR TITLE
Dropdown closes when clicked on currently opened or another drop down

### DIFF
--- a/jquery.dropkick-1.0.3.js
+++ b/jquery.dropkick-1.0.3.js
@@ -154,6 +154,12 @@
       setTimeout(function () {
         $select.hide();
       }, 0);
+
+      // Calls the onload after everything has finished loaded
+      if (data.settings.onload) {
+        data.settings.onload.call($select, $dk);
+      }
+
     });
   };
 


### PR DESCRIPTION
- When a user clicks on a currently opened dropdown, the dropdown will close.
- When a dropdown is opened, all currently opened dropdown will close.
