### PR TITLE
Ensure dropdowns closed when external clicks are made.

### DIFF
--- a/jquery.dropkick-1.0.3.js
+++ b/jquery.dropkick-1.0.3.js
@@ -375,6 +375,11 @@
         $dk.find('.dk_options_inner').addClass('scrollable vertical');
       }
 
+      // Close other open DK dropdowns, besides this one.
+      $('.dk_container').not($dk).each(function(){
+        _closeDropdown($(this));
+      });
+
       e.preventDefault();
       return false;
     });
@@ -424,7 +429,11 @@
     // Globally handle a click outside of the dropdown list by closing it.
     $(document).on('click', null, function(e) {
         if($(e.target).closest(".dk_container").length == 0) {
-            _closeDropdown($('.dk_toggle').parents(".dk_container").first());
+       	    // click is not within any DK dropdown, so all should be closed.
+       	    $('.dk_container').each(function(){
+       	    	_closeDropdown($(this));	
+       	    });
+            //_closeDropdown($('.dk_toggle').parents(".dk_container").first());
         }
     });
   });


### PR DESCRIPTION
Hi, thanks for managing this useful plugin. I've found a couple circumstances where dropdowns incorrectly remain open even when the document is clicked outside of them. The changes should address them.

1) Since line 384 prevents the event from bubbling, when a document click is made with any .dk_container, the event handler on line 430 will not be invoked and thus clicking on while DK dropdown while another is still open does not close the other one, as you would expect. The code on line 379 addresses this.

2) The commented out code on line 436 is incorrect; if any DK dropdown other than the first is open, it will remain open no matter where you click on the document. You should just close them all (as per the edit) since the desired behaviour is to close ALL of them in this case regardless.
