### PR TITLE
Add autoWidth default

### DIFF
--- a/jquery.dropkick.js
+++ b/jquery.dropkick.js
@@ -59,7 +59,8 @@
       theme         : false,
       changes       : false,
       syncReverse   : true,
-      nativeMobile  : true
+      nativeMobile  : true,
+      autoWidth     : true
     },
 
     // Make sure that only one dropdown is open the document
@@ -342,9 +343,11 @@
       $dk = build(dropdownTemplate, data);
 
       // Make the dropdown fixed width if desired
-      $dk.find('.dk_toggle').css({
-        'width' : width + 'px'
-      });
+     if (data.settings.autoWidth) {
+        $dk.find('.dk_toggle').css({
+          'width' : width + 'px'
+        });
+      }
 
       // Hide the <select> list and place our new one in front of it
       $select.before($dk).appendTo($dk);


### PR DESCRIPTION
Added autoWidth property to the defaults. This will allow for more granular control of the menu width. In particular when using percentage widths such as in responsive layouts. Utilizing inner options to set list items to overflow:hidden, whitespace:nowrap and text-overflow:ellipse works great to address longer items when the menu is too narrow.
