### PR TITLE
Update bower.json to suit the spec

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,9 @@
 {
   "name": "Robdel12/DropKick",
   "version": "1.4.0",
-  "main": "jquery.dropkick-min.js",
+  "main": "jquery.dropkick.js",
   "description": "A jQuery plugin for creating beautiful, graceful, and painless custom dropdowns.",
   "dependencies": {
-    "jquery": ">=1.10.2"
+    "jquery": ">=1.7"
   }
 }


### PR DESCRIPTION
- DropKick was tested and confirmed that works with jQuery 1.7+
- From the bower.json-spec: Do not include minified files.
