### PR TITLE
allow for optgroup label

### DIFF
--- a/dropkick.js
+++ b/dropkick.js
@@ -80,6 +80,11 @@ var
     // The optgroup template; An HTML string containing any sub-options is passed
     optgroup: [
       '<li class="dk-optgroup">',
+        '<% if (typeof(label) != "undefined") { %>',
+            '<span class="dk-optgroup-label">',
+                '<%= label %>',
+            '</span>',
+        '<% } %>',
         '<ul class="dk-optgroup-options">',
           '<%=( options )%>',
         '</ul>',
@@ -647,6 +652,7 @@ Dropkick.build = function( select ) {
           inner += _.tmpl( tmpl.option, { option: child });
         } else if ( child.nodeName === "OPTGROUP" ) {
           inner += _.tmpl( tmpl.optgroup, {
+            label: child.label,
             options: buildInner( child.children )
           });
         }


### PR DESCRIPTION
Allow for the addition of optgroup labels. Use class "dk-optgroup-label" for styling. 
