### PR TITLE
Add default options object if one doesn't exist

### DIFF
--- a/dropkick.js
+++ b/dropkick.js
@@ -24,6 +24,9 @@ var
   Dropkick = function( sel, opts ) {
     var i;
 
+    // Make sure an options object exists
+    this.opts = opts = opts || {};
+
     // Prevent DK on mobile
     if ( window.isMobile && !opts.mobile ) {
       return false;

--- a/tests/unit/tests.js
+++ b/tests/unit/tests.js
@@ -102,3 +102,9 @@ QUnit.test( "Checks if multi select is true", 1, function( assert ) {
 
   assert.equal(dk_multi.multiple, true);
 });
+
+QUnit.test("Checks if is a default opts object", 1, function( assert ) {
+  var dk = new Dropkick("#normal_select");
+
+  assert.equal(0, Object.keys(dk.opts).length);
+});


### PR DESCRIPTION
If options are not defined in the Dropkick object
some of the default logic will fail. This ensures
an options object, even if empty, is included.