### PR TITLE
IE9 width fix

### DIFF
--- a/css/dropkick.css
+++ b/css/dropkick.css
@@ -45,7 +45,8 @@
 .dk-select .dk-select-options {
   position: absolute;
   display: none;
-  left: 0; }
+  left: 0;
+  right: 0; }
 
 .dk-select-open-up .dk-select-options {
   border-radius: 0.4em 0.4em 0 0;
@@ -61,7 +62,8 @@
   max-height: 10em; }
 
 .dk-select-options {
-  width: 100%;
+  min-width: 100%;
+  width: auto;
   z-index: 100;
   background-color: white;
   border: 1px solid #CCCCCC;

--- a/css/dropkick.css
+++ b/css/dropkick.css
@@ -62,18 +62,18 @@
   max-height: 10em; }
 
 .dk-select-options {
-  min-width: 100%;
-  width: auto;
-  z-index: 100;
   background-color: white;
   border: 1px solid #CCCCCC;
   border-radius: 0.4em;
+  list-style: none;
+  margin: 0;
+  max-height: 10.5em;
+  min-width: 100%;
   overflow-x: hidden;
   overflow-y: auto;
-  max-height: 10.5em;
-  list-style: none;
   padding: 0.25em 0;
-  margin: 0; }
+  width: auto;
+  z-index: 100; }
 
 .dk-option-selected {
   background-color: #3297fd;

--- a/css/dropkick.scss
+++ b/css/dropkick.scss
@@ -102,18 +102,18 @@ $dk-disabled-color: #BBBBBB !default;
 }
 
 .dk-select-options {
-  min-width: 100%;
-  width: auto;
-  z-index: 100;
   background-color: white;
   border: 1px solid $dk-border-color;
   border-radius: $dk-border-radius;
+  list-style: none;
+  margin: 0;
+  max-height: 10.5em;
+  min-width: 100%;
   overflow-x: hidden;
   overflow-y: auto;
-  max-height: 10.5em;
-  list-style: none;
   padding: 0.25em 0;
-  margin: 0;
+  width: auto;
+  z-index: 100;
 }
 
 .dk-option-selected {

--- a/css/dropkick.scss
+++ b/css/dropkick.scss
@@ -82,6 +82,7 @@ $dk-disabled-color: #BBBBBB !default;
   position: absolute;
   display: none;
   left: 0;
+  right: 0;
 }
 
 .dk-select-open-up .dk-select-options {
@@ -101,7 +102,8 @@ $dk-disabled-color: #BBBBBB !default;
 }
 
 .dk-select-options {
-  width: 100%;
+  min-width: 100%;
+  width: auto;
   z-index: 100;
   background-color: white;
   border: 1px solid $dk-border-color;

--- a/production/css/dropkick.css
+++ b/production/css/dropkick.css
@@ -45,7 +45,8 @@
 .dk-select .dk-select-options {
   position: absolute;
   display: none;
-  left: 0; }
+  left: 0;
+  right: 0; }
 
 .dk-select-open-up .dk-select-options {
   border-radius: 0.4em 0.4em 0 0;
@@ -61,7 +62,8 @@
   max-height: 10em; }
 
 .dk-select-options {
-  width: 100%;
+  min-width: 100%;
+  width: auto;
   z-index: 100;
   background-color: white;
   border: 1px solid #CCCCCC;

--- a/production/css/dropkick.css
+++ b/production/css/dropkick.css
@@ -62,18 +62,18 @@
   max-height: 10em; }
 
 .dk-select-options {
-  min-width: 100%;
-  width: auto;
-  z-index: 100;
   background-color: white;
   border: 1px solid #CCCCCC;
   border-radius: 0.4em;
+  list-style: none;
+  margin: 0;
+  max-height: 10.5em;
+  min-width: 100%;
   overflow-x: hidden;
   overflow-y: auto;
-  max-height: 10.5em;
-  list-style: none;
   padding: 0.25em 0;
-  margin: 0; }
+  width: auto;
+  z-index: 100; }
 
 .dk-option-selected {
   background-color: #3297fd;


### PR DESCRIPTION
On a project where we are using Dropkick, a defect came through where on IE9 the dropdowns were 17px smaller than the container. After doing some research it looks like IE9 subtracts 17px for the scrollbar, and combined with overflow it unfortunately puts the scrollbar within the container, despite the 17px subtraction.

![IE9 -17px width issue](https://cloud.githubusercontent.com/assets/6495586/6216702/69d643b0-b5da-11e4-98d4-f7684b22bd86.png)

To fix this without having to stop the width from being dynamic, you just have to change the width from 100% to having a min-width of 100%. To be safe, I also added declarations for `width: auto;` and `right: 0;`. This still forces the UL containing the options to fill the width of the container, even on IE9 when the scrollbar is supposed to take up 17px. The min-width allows the UL to expand passed the "new 100% width" IE9 gives it under these circumstances, and the right: 0; allows it to not expand past the edge of the container.

![IE9 width fixed](https://cloud.githubusercontent.com/assets/6495586/6216759/cf3e69e4-b5da-11e4-8f61-231605f59805.png)

I've been testing this on numerous browsers and devices and it ended up passing QA for our project, so I figured I'd share to help others avoid having to debug this in the future. 