### PR TITLE
Update package.json main

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,7 @@
   "bugs": {
     "url": "http://github.com/robdel12/DropKick/issues"
   },
-  "main": [
-    "dist/dropkick.js",
-    "dist/css/dropkick.css"
-  ],
+  "main": "lib/dropkick.js",
   "description": "A JavaScript plugin for creating beautiful, graceful, and painless custom dropdowns.",
   "scripts": {
     "test": "gulp",


### PR DESCRIPTION
Update `main` to point to the main Dropkick js source. This way,
Dropkick is require-able with `require('dropkickjs')` rather than
`require('dropkickjs/lib/dropkick')`.