### PR TITLE
Add bubble change event option

### DIFF
--- a/lib/dropkick.js
+++ b/lib/dropkick.js
@@ -152,7 +152,12 @@ var
      * @type string
      *
      */
-    search: "strict"
+    search: "strict",
+
+    /**
+     * Bubble up the custom change event attached to Dropkick to the original element (select).
+     */
+    bubble: true
   },
 
   // Common Utilities
@@ -744,7 +749,7 @@ Dropkick.prototype = {
       this.value = select.value;
 
       if ( !disabled ) {
-        this.data.select.dispatchEvent( new CustomEvent( "change" ) );
+        this.data.select.dispatchEvent( new CustomEvent("change", {bubbles: this.data.settings.bubble}));
       }
 
       return elem;


### PR DESCRIPTION
CustomEvent takes a "bubbles" option that is set to false by default. By passing in an optional "true", we can fire the change event on the original select as well as the one in Dropkick.