### PR TITLE
Remove the extra check on location

### DIFF
--- a/lib/dropkick.js
+++ b/lib/dropkick.js
@@ -29,7 +29,7 @@ var
 
   // Browser testing stuff
   isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test( navigator.userAgent ),
-  isIframe = (window.parent !== window.self && location.host === parent.location.host),
+  isIframe = (window.parent !== window.self),
   isIE = navigator.appVersion.indexOf("MSIE")!==-1,
 
   /**


### PR DESCRIPTION
I noticed that, at least on Chrome, that the comparison `location.host === parent.location.host` causes a security exception and crashes horribly. The problem is that `parent.location.host` is not a query-able property when the iframe and parent have a different `document.domain`.

Perhaps this is an extra check that isn’t really required anyway?