### PR TITLE
Updated bower.json and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pure JS:
 
 You can install DropKick.js using bower:
 
-`bower install dropkick --save-dev`
+`bower install dropkick --save`
 
 
 ## npm Install

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,27 @@
 {
   "name": "dropkick",
   "main": [
-    "build/dropkick.js",
+    "build/js/dropkick.min.js",
     "build/css/dropkick.css"
   ],
   "description": "A JavaScript plugin for creating beautiful, graceful, and painless custom dropdowns.",
-  "version": "2.1.7"
+  "keywords": [
+    "dropkick",
+    "dropkickjs",
+    "select replacement",
+    "select2",
+    "select"
+  ],
+  "authors": [{
+    "name": "Robert DeLuca",
+    "email": "robertdeluca19@gmail.com"
+  }],
+  "homepage": "http://dropkickjs.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Robdel12/DropKick.git"
+  },
+  "dependencies": {
+    "jquery": "~2.1.4"
+  }
 }


### PR DESCRIPTION
1. The readme asks us to use `--save-dev` which isn't useful since DropKick is a front-end dependency. `--save` is the right command.
2. The path for the main file is wrong. I updated it to the correct path.
3. The bower.json file doesn't list jQuery as a dependency. Because of that, tools which import front-end assets may include them out of order, so that DropKick is imported _before_ jQuery. Spent some time debugging this today, see [grunt-bower-concat](https://github.com/sapegin/grunt-bower-concat) for an example of something that uses this.
4. `version` in bower.json [has been deprecated](https://github.com/bower/bower.json-spec#version).
5. I added some more data from the package.json file into bower.json. Why not? It'll make DropKick more searchable.

Let me know if you have any question! Or if you disagree with any of my points. Thanks.