### PR TITLE
Use the built file for modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bugs": {
     "url": "http://github.com/robdel12/DropKick/issues"
   },
-  "main": "lib/dropkick.js",
+  "main": "./build/js/dropkick.min.js",
   "description": "A JavaScript plugin for creating beautiful, graceful, and painless custom dropdowns.",
   "scripts": {
     "test": "gulp",


### PR DESCRIPTION
This is actually a pretty major and glaring error. Previously it wasn't
using the build file which left out polyfils.

Related to: #321