### PR TITLE
Added support for the hidden attribute on options.

### DIFF
--- a/lib/css/dropkick.css
+++ b/lib/css/dropkick.css
@@ -94,6 +94,9 @@
   color: #BBBBBB;
   background-color: transparent; }
 
+.dk-select-options .dk-option-hidden {
+  display: none; }
+
 .dk-optgroup {
   border: solid #CCCCCC;
   border-width: 1px 0;

--- a/lib/css/dropkick.scss
+++ b/lib/css/dropkick.scss
@@ -139,6 +139,10 @@ $dk-disabled-color: #BBBBBB !default;
   background-color: transparent;
 }
 
+.dk-select-options .dk-option-hidden {
+    display: none;
+}
+
 .dk-optgroup {
   border: solid $dk-border-color;
   border-width: 1px 0;

--- a/lib/dropkick.js
+++ b/lib/dropkick.js
@@ -329,6 +329,11 @@ Dropkick.prototype = {
         option.setAttribute( "aria-disabled", "true" );
       }
 
+      if ( elem.hidden ) {
+        _.addClass( option, "dk-option-hidden" );
+        option.setAttribute( "aria-hidden", "true" );
+      }
+
       this.data.select.add( elem, before );
 
       if ( typeof before === "number" ) {
@@ -691,6 +696,41 @@ Dropkick.prototype = {
     } else {
       elem.setAttribute( 'aria-disabled', false );
       _.removeClass( elem, disabledClass );
+    }
+  },
+
+  /**
+   * Hides or shows an option.
+   *
+   * @method hide
+   * @param  {Integer} elem     The element or index to hide
+   * @param  {Boolean} hidden   Whether or not to hide the element
+   * @example
+   *  ```js
+   *    var select = new Dropkick("#select");
+   *
+   *    // To hide an option with an index
+   *    select.hide(4, true);
+   *
+   *    // To make an option visible with an index
+   *    select.hide(4, false);
+   *  ```
+   */
+  hide: function( elem, hidden ) {
+    var hiddenClass = "dk-option-hidden";
+
+    if ( hidden === undefined ) {
+      hidden = true;
+    }
+
+    elem = this.item( elem );
+
+    if (hidden) {
+      elem.setAttribute( 'aria-hidden', true );
+      _.addClass( elem, hiddenClass );
+    } else {
+      elem.setAttribute( 'aria-hidden', false );
+      _.removeClass( elem, hiddenClass );
     }
   },
 
@@ -1244,6 +1284,11 @@ Dropkick.build = function( sel, idpre ) {
         if ( node.disabled ) {
           _.addClass( option, "dk-option-disabled" );
           option.setAttribute( "aria-disabled", "true" );
+        }
+
+        if ( node.hidden ) {
+          _.addClass( option, "dk-option-hidden" );
+          option.setAttribute( "aria-hidden", "true" );
         }
 
         if ( node.selected ) {

--- a/tests/unit/tests.js
+++ b/tests/unit/tests.js
@@ -158,6 +158,24 @@ QUnit.test( "Enable the one option in the select", 2, function( assert ) {
   assert.equal(dk.item(2).hasAttribute('aria-disabled', false), true);
 });
 
+QUnit.test( "Hide the one option in the select", 2, function ( assert ) {
+  var dk = new Dropkick('#normal_select');
+  dk.hide(2); // 2 = Alaska
+
+  assert.equal(_.hasClass(dk.item(2), "dk-option-hidden"), true);
+  assert.equal(dk.item(2).hasAttribute('aria-hidden', true), true);
+});
+
+QUnit.test( "Show the one option in the select", 2, function ( assert ) {
+  var dk = new Dropkick('#normal_select');
+  dk.hide(2); // 2 = Alaska
+  // Show the option again
+  dk.hide(2, false);
+  
+  assert.equal(_.hasClass(dk.item(2), "dk-option-hidden"), false);
+  assert.equal(dk.item(2).hasAttribute('aria-hidden', false), true);
+});
+
 QUnit.test( "Reset the selection", 2, function( assert ) {
   var dk = new Dropkick("#normal_select");
   dk.select(2); //2 = Alaska


### PR DESCRIPTION
When a user has a `hidden` attribute on an option in their select, that options `<li></li>` will receive the following:

- `.dk-option-hidden` class
- `aria-hidden="true"` property

The `.dk-option-hidden` class just tacks on a `display: none;` to hide the option from view, so it doesn't do anything special.

In addition a `.hide()` method has been added so a user can hide/show an option dynamically. Basically just forked from the `.disable()` method, the new method accepts two args: `elem` (the index/option the user wants to hide) and `hidden` (boolean for whether or not to show or hide the element).

Two unit tests for the `.hide()` method have also been added.