### PR TITLE
Potential XSS hole fix: e.text is not safe while e.innerHTML is

### DIFF
--- a/lib/dropkick.js
+++ b/lib/dropkick.js
@@ -315,7 +315,8 @@ Dropkick.prototype = {
       option = _.create( "li", {
         "class": "dk-option",
         "data-value": elem.value,
-        "innerHTML": elem.text,
+        "text": elem.text,
+        "innerHTML": elem.innerHTML,
         "role": "option",
         "aria-selected": "false",
         "id": "dk" + this.data.cacheID + "-" + ( elem.id || elem.value.replace( " ", "-" ) )
@@ -803,7 +804,7 @@ Dropkick.prototype = {
 
         combobox.setAttribute( "aria-activedescendant", elem.id );
         combobox.className = "dk-selected " + option.className;
-        combobox.innerHTML = option.text;
+        combobox.innerHTML = option.innerHTML;
 
         this.selectedOptions[0] = elem;
         option.selected = true;
@@ -1273,7 +1274,8 @@ Dropkick.build = function( sel, idpre ) {
         option = _.create( "li", {
           "class": "dk-option ",
           "data-value": node.value,
-          "innerHTML": node.text,
+          "text": node.text,
+          "innerHTML": node.innerHTML,
           "role": "option",
           "aria-selected": "false",
           "id": idpre + "-" + ( node.id || node.value.replace( " ", "-" ) )


### PR DESCRIPTION
While using the DropKick library in the [Facebook CTF platform](https://github.com/facebook/fbctf) we come across a successful attempt of Cross Site Scripting. After debugging we found the problem was on how new elements were created and how the ```innerHTML``` field was assigned a ```text``` element, and therefore, not encoded and insecure. This Pull Request should fix this problem and handle properly sanitized elements.
I will provide a simple example that shows the issue but ```gulp test``` runs with no problems:
```
[17:05:47] Took 93ms to run 54 tests. 54 passed, 0 failed.
[17:05:47] gulp-qunit: ✔ QUnit assertions all passed in runner.html
[17:05:47] Finished 'test' after 4.98 s
```