### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "dropkickjs",
   "version": "2.2.5",
+  "license": "MIT",
   "author": {
     "name": "Robert DeLuca"
   },


### PR DESCRIPTION
I was inspecting [dependencies](https://npm.anvaka.com/#/view/2d/redoc) of ReDoc and dropkickjs had unspecified license.